### PR TITLE
[wip]ajaxサーバーサイドの実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,11 +2,7 @@ $(function(){
 
   function buildMessage(message){
     var image = ""
-    if(message.image.url != null) {
-      image = `<img class="message__content" src="${message.image.url}">`}
-    else {
-      image = ""
-    }
+    if(message.image.url != null ? image = `<img class="message__content" src="${message.image.url}">` : image = "");
     var html = `<div class="message">
                   <div class="message__info">
                     <p class="message__info__talker">${message.name}</p>
@@ -35,8 +31,8 @@ $(function(){
     .done(function(message){
       var html = buildMessage(message);
       $(".messages").append(html);
-      $('#message_content').val('');
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+      $('.new_message')[0].reset();
     })
     .fail(function(){
       alert("メッセージの送信に失敗しました");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,25 @@
 $(function(){
+
+  function buildMessage(message){
+    var image = ""
+    if(message.image.url != null) {
+      image = `<img class="message__content" src="${message.image.url}">`}
+    else {
+      image = ""
+    }
+    var html = `<div class="message">
+                  <div class="message__info">
+                    <p class="message__info__talker">${message.name}</p>
+                    <p class="message__info__date">${message.date}</p>
+                  </div>
+                  <div class="message__content">
+                    ${message.content}
+                  </div>
+                  ${image}
+                </div>`
+    return html
+  }
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -6,10 +27,19 @@ $(function(){
     $.ajax({
       url: url,
       type: 'POST',
-      data: formData,  
+      data: formData,
       dataType: 'json',
       processData: false,
       contentType: false
     })
+    .done(function(message){
+      var html = buildMessage(message);
+      $(".messages").append(html);
+      $('#message_content').val('');
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+    })
+    .fail(function(){
+      alert("メッセージの送信に失敗しました");
+    })
   })
-})
+});

--- a/app/assets/stylesheets/modules/_chat-window.scss
+++ b/app/assets/stylesheets/modules/_chat-window.scss
@@ -94,8 +94,8 @@
       padding: 46px 40px;
       overflow: scroll;
       .message {
-        padding-bottom: 40px;
-        &__upper-info {
+        padding-top: 40px;
+        &__info {
           display: flex;
           margin-bottom: 10px;
           &__talker {
@@ -109,7 +109,7 @@
             margin-left: 10px;
           }
         }
-        &__text {
+        &__content {
           color: $textGray;
           font-size: 14px;
           margin-bottom: 10px;

--- a/app/assets/stylesheets/modules/_chat-window.scss
+++ b/app/assets/stylesheets/modules/_chat-window.scss
@@ -89,12 +89,12 @@
       }
     }
     .messages {
-      height: calc(100vh - 282px);
+      height: calc(100vh - 236px);
       background: #fafafa;
-      padding: 46px 40px;
+      padding: 46px 40px 0px;
       overflow: scroll;
       .message {
-        padding-top: 40px;
+        padding-bottom: 40px;
         &__info {
           display: flex;
           margin-bottom: 10px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: "メッセージを送信しました" }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,10 @@
 .message
-  .message__upper-info
-    %p.message__upper-info__talker<
+  .message__info
+    %p.message__info__talker<
       = message.user.name
-    %p.message__upper-info__date<
+    %p.message__info__date<
       = message.created_at.strftime("%Y/%m/%d %H:%M")
-  %p.message__text
-    - if message.content.present?
-      %p.lower-message__content
-        = message.content
-    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+  - if message.content.present?
+    .message__content
+      = message.content
+  = image_tag message.image.url, class: 'message__content' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.content @message.content
+json.image @message.image
+json.name @message.user.name
+json.date @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,5 +13,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.action_view.automatically_disable_submit_tag = false
   end
 end


### PR DESCRIPTION
# what
ajaxのリクエスト以降を実装する。
jbuilderを用いてデータをJSONで返し、jsファイルにdone/failそれぞれ実装する。
jbuilderにてメッセージ、画像、ユーザー名、日時を受け渡せるようにする。
jsファイルでは、画像があるかないか判別し、テンプレートに挿入する。
doneにアペンドやスクロール、フォームの更新、フォームを空にする記述を追加。
failにはアラート内容を記述。
disabledに関しては、application.rbにdisable_submitタグを追加しないよう記述する。

# why
非同期通信のリクエストまで実装できたので、データベースへ保存、JSONで返すことで、非同期で画面の更新が行える。