### PR TITLE
自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,7 +4,7 @@ $(function(){
     var image = ""
     if(message.image.url != null ? image = `<img class="message__content" src="${message.image.url}">` : image = "");
     var html = `
-      <div class="message">
+      <div class="message" data-id="${message.id}">
         <div class="message__info">
           <p class="message__info__talker">${message.name}</p>
           <p class="message__info__date">${message.date}</p>

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -15,36 +15,32 @@ $(function(){
       </div>`;
     return html;
   }
-  $(window).on('load',function(){
+  
+  var reloadMessages = function() {
     if(document.URL.match(/messages/)) {
-      var reloadMessages = function() {
-        last_message_id = $('.message').last().attr('data-id');
-        $.ajax({
-          url: 'api/messages',
-          type: 'get',
-          dataType: 'json',
-          data: {id: last_message_id}
-        })
-        .done(function(messages) {
-          if (messages.length !== 0) {
-            messages.forEach(function(message) {
-              var html = buildMessage(message);
-              $(".messages").append(html);
-              $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
-            });
-          } else {
-            return false;
-          }
-        })
-        .fail(function() {
-          console.log('error');
-        });
-      };
-      setInterval(reloadMessages, 5000);
-    } else {
-      return false
+      last_message_id = $('.message').last().attr('data-id');
+      $.ajax({
+        url: 'api/messages',
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+          messages.forEach(function(message) {
+            var html = buildMessage(message);
+            $(".messages").append(html);
+            $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+          });
+        } else {
+          return false;
+        }
+      })
+      .fail(function() {
+        console.log('error');
+      });
     }
-  });
+  };
   
 
   $('#new_message').on('submit', function(e){
@@ -69,4 +65,6 @@ $(function(){
       alert("メッセージの送信に失敗しました");
     })
   })
+
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,4 +39,25 @@ $(function(){
       alert("メッセージの送信に失敗しました");
     })
   })
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $('.message').attr('data-id').max();
+    console.log(last_message_id);
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: 'api/messages',
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,6 @@
 $(function(){
   function buildMessage(message){
-    var image = ""
-    if(message.image.url ? image = `<img class="message__content" src="${message.image.url}">` : image = "");
+    var image = message.image.url ? image = `<img class="message__content" src="${message.image.url}">` : image = "";
     var html = `
       <div class="message" data-id="${message.id}">
         <div class="message__info">
@@ -37,7 +36,7 @@ $(function(){
         }
       })
       .fail(function() {
-        console.log('error');
+        alert("自動更新に失敗しました");
       });
     }
   };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,6 @@
 $(function(){
   function buildMessage(message){
-    var image = message.image.url ? image = `<img class="message__content" src="${message.image.url}">` : image = "";
+    var image = message.image.url ? `<img class="message__content" src="${message.image.url}">` : "";
     var html = `
       <div class="message" data-id="${message.id}">
         <div class="message__info">

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,7 @@
 $(function(){
-
   function buildMessage(message){
     var image = ""
-    if(message.image.url != null ? image = `<img class="message__content" src="${message.image.url}">` : image = "");
+    if(message.image.url ? image = `<img class="message__content" src="${message.image.url}">` : image = "");
     var html = `
       <div class="message" data-id="${message.id}">
         <div class="message__info">
@@ -14,8 +13,34 @@ $(function(){
         </div>
         ${image}
       </div>`;
-    return html
+    return html;
   }
+
+  var reloadMessages = function() {
+    last_message_id = $('.message').attr('data-id').max();
+    console.log(last_message_id);
+    $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+      var insertHTML = '';
+      if (messages.length !== 0) {
+        messages.forEach(function(message) {
+          buildMessage(message);
+        });
+      } else {
+        return false;
+      }
+      $(".messages").append(html);
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -40,24 +65,6 @@ $(function(){
     })
   })
 
-  var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-    last_message_id = $('.message').attr('data-id').max();
-    console.log(last_message_id);
-    $.ajax({
-      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
-      url: 'api/messages',
-      //ルーティングで設定した通りhttpメソッドをgetに指定
-      type: 'get',
-      dataType: 'json',
-      //dataオプションでリクエストに値を含める
-      data: {id: last_message_id}
-    })
-    .done(function(messages) {
-      console.log('success');
-    })
-    .fail(function() {
-      console.log('error');
-    });
-  };
+  setInterval(reloadMessages, 5000);
+  
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -15,32 +15,37 @@ $(function(){
       </div>`;
     return html;
   }
-
-  var reloadMessages = function() {
-    last_message_id = $('.message').attr('data-id').max();
-    console.log(last_message_id);
-    $.ajax({
-      url: 'api/messages',
-      type: 'get',
-      dataType: 'json',
-      data: {id: last_message_id}
-    })
-    .done(function(messages) {
-      console.log('success');
-      var insertHTML = '';
-      if (messages.length !== 0) {
-        messages.forEach(function(message) {
-          buildMessage(message);
+  $(window).on('load',function(){
+    if(document.URL.match(/messages/)) {
+      var reloadMessages = function() {
+        last_message_id = $('.message').last().attr('data-id');
+        $.ajax({
+          url: 'api/messages',
+          type: 'get',
+          dataType: 'json',
+          data: {id: last_message_id}
+        })
+        .done(function(messages) {
+          if (messages.length !== 0) {
+            messages.forEach(function(message) {
+              var html = buildMessage(message);
+              $(".messages").append(html);
+              $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+            });
+          } else {
+            return false;
+          }
+        })
+        .fail(function() {
+          console.log('error');
         });
-      } else {
-        return false;
-      }
-      $(".messages").append(html);
-    })
-    .fail(function() {
-      console.log('error');
-    });
-  };
+      };
+      setInterval(reloadMessages, 5000);
+    } else {
+      return false
+    }
+  });
+  
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -64,7 +69,4 @@ $(function(){
       alert("メッセージの送信に失敗しました");
     })
   })
-
-  setInterval(reloadMessages, 5000);
-  
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image
-  json.created_at message.created_at
-  json.user_name message.user.name
+  json.name message.user.name
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,10 +1,10 @@
-.message
+.message{data: {id: message.id}}
   .message__info
     %p.message__info__talker<
       = message.user.name
     %p.message__info__date<
       = message.created_at.strftime("%Y/%m/%d %H:%M")
   - if message.content.present?
-    .message__content
+    .message__content{data: {id: message}}
       = message.content
   = image_tag message.image.url, class: 'message__content' if message.image.present?

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -5,6 +5,6 @@
     %p.message__info__date<
       = message.created_at.strftime("%Y/%m/%d %H:%M")
   - if message.content.present?
-    .message__content{data: {id: message}}
+    .message__content
       = message.content
   = image_tag message.image.url, class: 'message__content' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
-json.content @message.content
-json.image @message.image
+json.(@message, :content, :image)
 json.name @message.user.name
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# what
チャット画面が自動で更新されるようにする。
数秒ごとに表示されている最新のメッセージのidをリクエスト、それ以降に保存されたメッセージを取得する。取得したメッセージをjsで加工しビューに描画する

# why
自分以外のユーザーが投稿した内容も自動で表示できるようになり、よりインタラクティブになる。